### PR TITLE
Change Rviz2 output topics to relative names that the namespace is ap…

### DIFF
--- a/launch/eduard_monitor_nav2.launch.py
+++ b/launch/eduard_monitor_nav2.launch.py
@@ -33,7 +33,11 @@ def generate_launch_description():
       arguments=['-d', rviz_config],
       parameters=[
         {'use_sim_time': use_sim_time}
-      ]      
+      ],
+      remappings=[
+        ('/goal_pose', 'goal_pose'),
+        ('/initialpose', 'initialpose')
+      ]    
     )
 
     # Robot Description for Eduard


### PR DESCRIPTION
Remap Rviz2 topics /goal_pose and /initialpose from absolute to to relative topic names. This way the namespace is applied to the topic names as one expects.